### PR TITLE
Remove hardcoded jsonl variable

### DIFF
--- a/dagster_meltano/meltano_elt.py
+++ b/dagster_meltano/meltano_elt.py
@@ -77,7 +77,6 @@ class MeltanoELT:
                 cwd=os.getenv('MELTANO_PROJECT_ROOT'),  # Start the command in the root of the Meltano project
                 env={
                     **os.environ,  # Pass all environment variables from the Dagster environment
-                    'TARGET_JSONL_DESTINATION_PATH': 'fresh' 
                 },
                 preexec_fn=pre_exec,
             )


### PR DESCRIPTION
I was playing around with this locally and the Dagster pipeline fails as the path /fresh isn't created by default when using Meltano install. Realised it was being hardcoded so thought it would be better for the user to define this in meltano.yml