### PR TITLE
added a meltano elt solid and unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,5 +24,7 @@ jobs:
           pip install ".[development]"
       - name: Run test suite
         run: |
+          cd meltano/
           meltano install
+          cd ..
           pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,4 +24,5 @@ jobs:
           pip install ".[development]"
       - name: Run test suite
         run: |
+          meltano install
           pytest

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ A dagster plugin that allows you to run Meltano pipelines using Dagster.
 An example of a Dagster pipeline that runs a Meltano elt process.
 
 ```python
-
-from dagster import OutputDefinition, Nothing
-from dagster_meltano.tests import pipeline
-from dagster_meltano.solids import meltano_elt_solid
+import json
+from dagster import OutputDefinition, Nothing, pipeline
+from dagster_meltano.solids import meltano_elt_constructor
 
 
 @pipeline
 def meltano_pipeline():
-    meltano_elt_solid(
+    meltano_elt_constructor(
         output_defs=[OutputDefinition(dagster_type=Nothing)],
-        tap='tap-csv',
-        target='target-jsonl',
-        job_id='csv-to-jsonl'  # Optional
+        tap="tap-csv",
+        target="target-jsonl",
+        job_id="csv-to-jsonl",
+        env_vars={"TAP_CSV__SELECT": json.dumps(["sample.id"])},
     )
 ```
 

--- a/dagster_meltano/solids.py
+++ b/dagster_meltano/solids.py
@@ -7,20 +7,76 @@ from dagster import (
     AssetMaterialization,
     Field,
     InputDefinition,
+    Nothing,
     Optional,
     OutputDefinition,
     SolidDefinition,
     SolidExecutionContext,
     check,
+    solid,
 )
 
 from dagster_meltano.meltano_elt import MeltanoELT
 
 
 def run_elt(
+    name: str,
+    tap: str,
+    target: str,
+    job_id: str,
+    full_refresh: bool,
+    env_vars: Optional[dict],
+    log: SolidExecutionContext.log,
+) -> Generator[AssetMaterialization, None, None]:
+    """Run `meltano elt` command yielding asset materialization and producing logs.
+
+    Args:
+        name (str): The name of the solid.
+        tap (str): The name of the Meltano tap.
+        target (str): The name of the Meltano target.
+        job_id (str): The id of the job.
+        full_refresh (bool): Whether to ignore existing state.
+        env_vars (Optional[dict]): Additional environment variables to pass to the
+            command context.
+        log (SolidExecutionContext.log): The solid execution context's logger.
+    """
+    meltano_elt = MeltanoELT(
+        tap=tap,
+        target=target,
+        job_id=job_id,
+        full_refresh=full_refresh,
+        env_vars=env_vars,
+    )
+
+    for line in meltano_elt.logs:
+        log.info(line)
+
+    meltano_elt.elt_process.wait()
+
+    return_code = meltano_elt.elt_process.returncode
+
+    if return_code != 0:
+        error = f"The meltano elt failed with code {return_code}"
+        log.error(error)
+        raise Exception(error)
+    else:
+        log.info(f"Meltano exited with return code {return_code}")
+
+    yield AssetMaterialization(
+        asset_key=name,
+        metadata={
+            "Tap": tap,
+            "Target": target,
+            "Job ID": job_id,
+            "Full Refresh": "True" if full_refresh else "False",
+        },
+    )
+
+
+def elt_factory(
     name: str, tap: str, target: str, job_id: str, env_vars: Optional[dict]
 ) -> FunctionType:
-    """Run `meltano elt` command yielding asset materialization and producing logs."""
+    """Produce solid command for defining solid at construction time."""
     check.str_param(name, "name")
     check.str_param(tap, "tap")
     check.str_param(target, "target")
@@ -41,42 +97,35 @@ def run_elt(
 
         log = step_context.log
 
-        meltano_elt = MeltanoELT(
-            tap=tap,
-            target=target,
-            job_id=job_id,
-            full_refresh=full_refresh,
-            env_vars=env_vars,
-        )
-
-        for line in meltano_elt.logs:
-            log.info(line)
-
-        meltano_elt.elt_process.wait()
-
-        return_code = meltano_elt.elt_process.returncode
-
-        if return_code != 0:
-            error = f"The meltano elt failed with code {return_code}"
-            log.error(error)
-            raise Exception(error)
-        else:
-            log.info(f"Meltano exited with return code {return_code}")
-
-        yield AssetMaterialization(
-            asset_key=name,
-            metadata={
-                "Tap": tap,
-                "Target": target,
-                "Job ID": job_id,
-                "Full Refresh": "True" if full_refresh else "False",
-            },
-        )
+        return run_elt(name, tap, target, job_id, full_refresh, env_vars, log)
 
     return command
 
 
-def meltano_elt_solid(
+def optional_args(name, tap, target, job_id) -> (str, str):
+    """Resolve optional Meltano elt args.
+
+    Args:
+        name (str): The name of the solid.
+        tap (str): The name of the Meltano tap.
+        target (str): The name of the Meltano target.
+        job_id (str): The id of the job.
+    """
+    # If no name is specified, create a name based on the tap and target name
+    if not name:
+        name = f"{tap}_{target}"
+
+    # Solid names cannot contain dashes
+    name = name.replace("-", "_")
+
+    # If no job id is defined, we base it on the tap and target name
+    if not job_id:
+        job_id = f"{tap}-{target}"
+
+    return name, job_id
+
+
+def meltano_elt_constructor(
     tap: str,
     target: str,
     input_defs: Optional[List[InputDefinition]] = None,
@@ -87,8 +136,19 @@ def meltano_elt_solid(
 ) -> SolidDefinition:
     """Create a solid for a meltano elt process.
 
+    Note that you can only use `meltano_elt_constructor` if you know the command you'd like to execute
+    at pipeline construction time. If you'd like to construct shell commands dynamically during
+    pipeline execution and pass them between solids, you should use `meltano_elt_solid` instead.
+
     Args:
+        tap (str): The name of the Meltano tap.
+        target (str): The name of the Meltano target.
+        input_defs (Optional[List[InputDefinition]]): Input definitions for the solid.
+        output_defs (Optional[List[OutputDefinition]]): Output definitions for the solid.
         name (str): The name of the solid.
+        job_id (str): The id of the job.
+        env_vars (Optional[dict]): Additional environment variables to pass to the
+            command context.
 
     Returns:
         SolidDefinition: The solid that runs the Meltano ELT process.
@@ -102,16 +162,7 @@ def meltano_elt_solid(
     check.opt_str_param(name, "name")
     check.opt_str_param(job_id, "job_id")
 
-    # If no name is specified, create a name based on the tap and target name
-    if not name:
-        name = f"{tap}_{target}"
-
-    # Solid names cannot contain dashes
-    name = name.replace("-", "_")
-
-    # If no job id is defined, we base it on the tap and target name
-    if not job_id:
-        job_id = f"{tap}-{target}"
+    name, job_id = optional_args(name, tap, target, job_id)
 
     # Add a default tag to indicate this is a Meltano solid
     default_tags = {"kind": "meltano"}
@@ -120,7 +171,7 @@ def meltano_elt_solid(
         name=name,
         input_defs=input_defs,
         output_defs=output_defs,
-        compute_fn=run_elt(
+        compute_fn=elt_factory(
             name=name,
             tap=tap,
             target=target,
@@ -138,3 +189,67 @@ def meltano_elt_solid(
         description="",
         tags={**default_tags},
     )()
+
+
+@solid(
+    name="meltano_elt_solid",
+    description=(
+        "This solid executes a Meltano elt command it receives as input.\n\n"
+        "This solid is suitable for uses where the command to execute is generated dynamically by "
+        "upstream solids. If you know the command to execute at pipeline construction time, consider"
+        "`meltano_elt_constructor` instead."
+    ),
+    output_defs=[OutputDefinition(dagster_type=Nothing)],
+    config_schema={
+        "full_refresh": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Whether to ignore existing state.",
+        ),
+        "env_vars": Field(
+            dict,
+            default_value={},
+            is_required=False,
+            description="Additional environment variables to pass to the shell command."
+            "Overwrites conflicting variables passed from upstream solids/ops.",
+        ),
+    },
+    tags={"kind": "meltano"},
+)
+def meltano_elt_solid(
+    context, elt_args: dict, env_vars: Optional[dict] = None
+) -> Generator[AssetMaterialization, None, None]:
+    """This solid executes a Meltano elt command it receives as input.
+
+    This solid is suitable for uses where the command to execute is generated dynamically by
+    upstream solids. If you know the command to execute at pipeline construction time, consider
+    `meltano_elt_constructor` instead.
+
+    Args:
+        context (SolidExecutionContext): Execution context for the solid
+        elt_args (Dict[str: str]): Dictionary of arguments for a meltano elt command. Must
+            include `tap` and `target`. Can include `name` and `job_id`.
+        env_vars (dict): Additional environment variables to pass to the command context.
+            Overwritten by conflicting variables passed in through config.
+    """
+    if env_vars is None:
+        env_vars = {}
+
+    # validate elt_args key names
+    rqd_keys = ["tap", "target"]
+    for k in rqd_keys:
+        if not elt_args[k]:
+            raise context.log.error(f"elt_args requires the '{k}' key")
+
+    # resolve elt command args
+    name = elt_args.get("name")
+    tap = elt_args.get("tap")
+    target = elt_args.get("target")
+    job_id = elt_args.get("job_id")
+    name, job_id = optional_args(name, tap, target, job_id)
+    full_refresh = context.solid_config["full_refresh"]
+    env_vars = {**env_vars, **context.solid_config["env_vars"]}
+
+    # run command
+    return run_elt(name, tap, target, job_id, full_refresh, env_vars, context.log)

--- a/dagster_meltano/tests/constructor.py
+++ b/dagster_meltano/tests/constructor.py
@@ -1,15 +1,15 @@
-"""Smoke test for testing Meltano commands in dagster pipelines"""
+"""Smoke test for testing Meltano commands in dagster pipelines using the constructor method."""
 
 import json
 
 from dagster import Nothing, OutputDefinition, pipeline
 
-from dagster_meltano.solids import meltano_elt_solid
+from dagster_meltano.solids import meltano_elt_constructor
 
 
 @pipeline
-def meltano_pipeline():
-    meltano_elt_solid(
+def meltano_constructor():
+    meltano_elt_constructor(
         output_defs=[OutputDefinition(dagster_type=Nothing)],
         tap="tap-csv",
         target="target-jsonl",

--- a/dagster_meltano/tests/repo.py
+++ b/dagster_meltano/tests/repo.py
@@ -1,0 +1,14 @@
+from dagster import repository
+
+from dagster_meltano.tests.constructor import meltano_constructor
+from dagster_meltano.tests.solid import meltano_solid
+
+
+@repository
+def repository_example():
+    return {
+        "pipelines": {
+            "meltano_constructor": lambda: meltano_constructor,
+            "meltano_solid": lambda: meltano_solid,
+        }
+    }

--- a/dagster_meltano/tests/solid.py
+++ b/dagster_meltano/tests/solid.py
@@ -1,0 +1,26 @@
+"""Smoke test for testing Meltano commands in dagster pipelines using the solid method"""
+
+import json
+
+from dagster import pipeline, solid
+
+from dagster_meltano.solids import meltano_elt_solid
+
+
+@solid
+def elt_args():
+    return {
+        "tap": "tap-csv",
+        "target": "target-jsonl",
+        "job_id": "csv-to-jsonl",
+    }
+
+
+@solid
+def env_vars():
+    return {"TAP_CSV__SELECT": json.dumps(["sample.id"])}
+
+
+@pipeline
+def meltano_solid():
+    meltano_elt_solid(elt_args=elt_args(), env_vars=env_vars())

--- a/dagster_meltano/tests/test_meltano_elt.py
+++ b/dagster_meltano/tests/test_meltano_elt.py
@@ -2,14 +2,24 @@ import pytest
 
 from dagster_meltano.meltano_elt import MeltanoELT
 
+meltano_elt = MeltanoELT(
+    tap="tap-csv", target="target-csv", job_id="tap-csv-target-json", full_refresh=True
+)
+
 
 def test_meltano_elt_construction():
     """On successfull creation no errors should be raised."""
-    meltano_elt = MeltanoELT(
-        tap="tap-csv", target="target-csv", job_id="tap-csv-target-json", full_refresh=True
-    )
 
     assert isinstance(meltano_elt, MeltanoELT)
+    assert meltano_elt.elt_command == [
+        "meltano",
+        "elt",
+        "tap-csv",
+        "target-csv",
+        "--job_id",
+        "tap-csv-target-json",
+        "--full-refresh",
+    ]
 
 
 def test_meltano_elt_missing_params():

--- a/dagster_meltano/tests/test_meltano_elt.py
+++ b/dagster_meltano/tests/test_meltano_elt.py
@@ -27,9 +27,7 @@ def _create_meltano_elt(full_refresh: bool = True) -> MeltanoELT:
 
 
 def test_meltano_elt_construction():
-    """
-    On successfull creation no errors should be raised.
-    """
+    """On successfull creation no errors should be raised."""
     meltano_elt = _create_meltano_elt()
 
     # Test if the instance is of the right type
@@ -38,7 +36,7 @@ def test_meltano_elt_construction():
         "meltano",
         "elt",
         "tap-csv",
-        "target-csv",
+        "target-json",
         "--job_id",
         "tap-csv-target-json",
         "--full-refresh",
@@ -46,9 +44,7 @@ def test_meltano_elt_construction():
 
 
 def test_meltano_elt_command():
-    """
-    Test if the generated meltano elt command is of the correct format.
-    """
+    """Test if the generated meltano elt command is of the correct format."""
     meltano_elt = _create_meltano_elt()
 
     # Test if the command is of the right format
@@ -64,9 +60,7 @@ def test_meltano_elt_command():
 
 
 def test_meltano_elt_command_no_refresh():
-    """
-    Test whether the '--full-refresh' flag is omitted if no full refresh is requested.
-    """
+    """Test whether the '--full-refresh' flag is omitted if no full refresh is requested."""
     meltano_elt = _create_meltano_elt(full_refresh=False)
 
     # Make sure that the full refresh flag is missing

--- a/dagster_meltano/tests/test_solids.py
+++ b/dagster_meltano/tests/test_solids.py
@@ -7,6 +7,9 @@ from dagster import AssetMaterialization, execute_solid
 from dagster_meltano.solids import meltano_elt_solid
 
 
+os.environ["MELTANO_PROJECT_ROOT"] = (Path(__file__).parents[2] / 'meltano').__str__()
+
+
 def test_meltano_elt_solid_explicit_params():
     result = execute_solid(
         meltano_elt_solid,

--- a/dagster_meltano/tests/test_solids.py
+++ b/dagster_meltano/tests/test_solids.py
@@ -1,0 +1,115 @@
+import json
+import os
+from pathlib import Path
+
+from dagster import AssetMaterialization, execute_solid
+
+from dagster_meltano.solids import meltano_elt_solid
+
+
+def test_meltano_elt_solid_explicit_params():
+    result = execute_solid(
+        meltano_elt_solid,
+        input_values={
+            "elt_args": {
+                "name": "csv",
+                "tap": "tap-csv",
+                "target": "target-jsonl",
+                "job_id": "tap-csv-target-json",
+            },
+        },
+    )
+
+    mtrls = result.materializations_during_compute
+    mtrl = mtrls[0]
+
+    metadata = {}
+    for entry in mtrls[0].metadata_entries:
+        metadata[entry.label] = entry.entry_data.text
+
+    assert result.success
+    assert len(result.materializations_during_compute) == 1
+    assert isinstance(mtrl, AssetMaterialization)
+    assert mtrl.asset_key[0][0] == "csv"
+    assert metadata["Tap"] == "tap-csv"
+    assert metadata["Target"] == "target-jsonl"
+    assert metadata["Job ID"] == "tap-csv-target-json"
+    assert metadata["Full Refresh"] == "False"
+
+
+def test_meltano_elt_solid_nonexplicit_params():
+    """Auto-generated inputs values match requirements."""
+    result = execute_solid(
+        meltano_elt_solid,
+        input_values={
+            "elt_args": {
+                "tap": "tap-csv",
+                "target": "target-jsonl",
+            },
+        },
+    )
+
+    mtrls = result.materializations_during_compute
+    mtrl = mtrls[0]
+
+    metadata = {}
+    for entry in mtrls[0].metadata_entries:
+        metadata[entry.label] = entry.entry_data.text
+
+    assert result.success
+    assert len(result.materializations_during_compute) == 1
+    assert isinstance(mtrl, AssetMaterialization)
+    assert mtrl.asset_key[0][0] == "tap_csv_target_jsonl"
+    assert metadata["Tap"] == "tap-csv"
+    assert metadata["Target"] == "target-jsonl"
+    assert metadata["Job ID"] == "tap-csv-target-jsonl"
+    assert metadata["Full Refresh"] == "False"
+
+
+def test_meltano_elt_solid_env_vars():
+    """Config env vars should override input provided env vars."""
+    output_filepath = Path(os.environ["MELTANO_PROJECT_ROOT"]) / "load" / "sample.jsonl"
+
+    def len_output_file(filepath):
+        with open(filepath, "r", encoding="utf-8") as f:
+            file = f.read()
+        return len(file)
+
+    initial_output_file_len = len_output_file(output_filepath)
+
+    result = execute_solid(
+        meltano_elt_solid,
+        run_config={
+            "solids": {
+                "meltano_elt_solid": {
+                    "config": {"env_vars": {"TAP_CSV__SELECT": json.dumps(["!sample.*"])}}
+                }
+            }
+        },
+        input_values={
+            "elt_args": {
+                "tap": "tap-csv",
+                "target": "target-jsonl",
+                "env_vars": {"TAP_CSV__SELECT": json.dumps(["test_value"])},
+            },
+        },
+    )
+
+    final_output_file_len = len_output_file(output_filepath)
+
+    mtrls = result.materializations_during_compute
+    mtrl = mtrls[0]
+
+    metadata = {}
+    for entry in mtrls[0].metadata_entries:
+        metadata[entry.label] = entry.entry_data.text
+
+    assert result.success
+    assert len(result.materializations_during_compute) == 1
+    assert isinstance(mtrl, AssetMaterialization)
+    assert mtrl.asset_key[0][0] == "tap_csv_target_jsonl"
+    assert metadata["Tap"] == "tap-csv"
+    assert metadata["Target"] == "target-jsonl"
+    assert metadata["Job ID"] == "tap-csv-target-jsonl"
+    assert metadata["Full Refresh"] == "False"
+    assert initial_output_file_len == final_output_file_len


### PR DESCRIPTION
Added a solid for Meltano ELT runs. This better fits the use case where you don't know the elt command (or the env vars) at the time of code compilation. This is how I typically use meltano in my dagster environment. The configuration of my env variables var depending on the execution so I have to pass them in from upstream solids. I also added some unit tests for this and refactored naming conventions in order to provide clarity. But this can all be debated. I'm not strongly tied to my naming conventions.