### PR TITLE
Selecting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .meltano
 .vscode
 meltano/load/sample.jsonl
+tmp**/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ def meltano_pipeline():
             "destination_path": "load"
         },
         env_vars={"TAP_CSV__SELECT": json.dumps(["sample.id"])},
+        select_patterns=[["sample", "first_name"], ["--list", "--all"]]
     ).solid()
 ```
 
@@ -37,9 +38,13 @@ You can also inject information from previous solids during runtime.
 
 ```python
 import json
-from dagster import OutputDefinition, Nothing, pipeline
+from dagster import pipeline, solid
 from dagster_meltano.solids import MeltanoEltSolid
-from dagster_meltano.dagster_types import MeltanoEltArgsType, MeltanoEnvVarsType
+from dagster_meltano.dagster_types import (
+    MeltanoEltArgsType,
+    MeltanoEnvVarsType,
+    MeltanoSelectPatternsType,
+)
 
 @solid
 def elt_args() -> MeltanoEltArgsType:
@@ -53,6 +58,10 @@ def elt_args() -> MeltanoEltArgsType:
 def env_vars() -> MeltanoEnvVarsType:
     return {"TAP_CSV__SELECT": json.dumps(["sample.id"])}
 
+@solid
+def select_patterns() -> MeltanoSelectPatternsType:
+    return [["sample", "*"], ['--list', '--all']]
+
 @pipeline
 def meltano_pipeline():
     MeltanoEltSolid(
@@ -63,7 +72,8 @@ def meltano_pipeline():
         }
     ).solid(
         elt_args=elt_args(), 
-        env_vars=env_vars()
+        env_vars=env_vars(),
+        select_patterns=select_patterns(),
     )
 ```
 

--- a/dagster_meltano/dagster_types.py
+++ b/dagster_meltano/dagster_types.py
@@ -5,9 +5,29 @@ def _is_dict(elt_args: dict) -> bool:
     return isinstance(elt_args, dict)
 
 
+def _is_list_of_lists(patterns: list) -> bool:
+    if len(patterns) == 0:
+        return isinstance(patterns, list)
+    else:
+        for pattern in patterns:
+            if not isinstance(pattern, list):
+                return False
+
+            for arg in pattern:
+                if not isinstance(arg, str):
+                    return False
+
+    return True
+
+
 @dagster_type_loader(config_schema={})
 def load_empty_dict(_context, value):  # pylint: disable=unused-argument
     return {}
+
+
+@dagster_type_loader(config_schema={})
+def load_empty_list(_context, value):  # pylint: disable=unused-argument
+    return []
 
 
 MeltanoEltArgsType = DagsterType(
@@ -16,6 +36,15 @@ MeltanoEltArgsType = DagsterType(
     description='Meltano elt arguments, you can define a "tap", "target" and "job_id" key.',
     typing_type=dict,
     loader=load_empty_dict,
+)
+
+MeltanoSelectPatternsType = DagsterType(
+    name="MeltanoSelectPatterns",
+    type_check_fn=lambda _, select_patterns: _is_list_of_lists(select_patterns),
+    description="""Meltano select patterns provided as a list of lists (e.g.,
+    [['entity', 'attribute'], ['--rm', 'entity', 'attribute']]""",
+    typing_type=list,
+    loader=load_empty_list,
 )
 
 MeltanoEnvVarsType = DagsterType(

--- a/dagster_meltano/meltano_elt.py
+++ b/dagster_meltano/meltano_elt.py
@@ -10,15 +10,13 @@ from dagster import AssetMaterialization, Failure, SolidExecutionContext
 from dagster_meltano.utils import lower_kebab_to_upper_snake_case
 
 
-class MeltanoELT:
-    """Control `meltano elt` command."""
+class MeltanoCore:
+    """Common functionality necessary for all meltano cli commands."""
 
     def __init__(
         self,
         tap: str,
         target: str,
-        job_id: str,
-        full_refresh: bool,
         tap_config: Optional[dict] = None,
         target_config: Optional[dict] = None,
         env_vars: Optional[dict] = None,
@@ -28,8 +26,8 @@ class MeltanoELT:
         Args:
             tap (str): The name of the Meltano tap.
             target (str): The name of the Meltano target.
-            job_id (str): The id of the job.
-            full_refresh (bool): Whether to ignore existing state.
+            tap_config (Optional[dict]): Additional environment variables relevant to the tap.
+            target_config (Optional[dict]): Additional environment variables relevant to the target.
             env_vars (Optional[dict]): Additional environment variables to pass to the
                 command context.
         """
@@ -42,28 +40,11 @@ class MeltanoELT:
 
         self._tap = tap
         self._target = target
-        self._job_id = job_id
-        self._full_refresh = full_refresh
         self._env_vars = env_vars
         self._tap_config = tap_config
         self._target_config = target_config
-        self._elt_process = None
-
-    @property
-    def elt_command(self) -> List[str]:
-        """Constructs all the parts of the ELT command.
-
-        Returns:
-            List[str]: All parts of the ELT command.
-        """
-        # All default parts of the command
-        elt_command = ["meltano", "elt", self._tap, self._target, "--job_id", self._job_id]
-
-        # If the user specified a full refresh
-        if self._full_refresh:
-            elt_command += ["--full-refresh"]
-
-        return elt_command
+        self._command = None
+        self._meltano_process = None
 
     @property
     def _target_config_env_vars(self):
@@ -80,7 +61,7 @@ class MeltanoELT:
         }
 
     @property
-    def elt_process(self) -> Popen:
+    def meltano_process(self) -> Popen:
         """Creates a subprocess that runs the Meltano ELT command.
         It is started in the Meltano project root, and inherits environment.
         variables from the Dagster environment.
@@ -91,9 +72,9 @@ class MeltanoELT:
             Popen: The ELT process.
         """
         # Create a Meltano ELT process if it does not already exists
-        if not self._elt_process:
-            self._elt_process = Popen(
-                self.elt_command,
+        if not self._meltano_process:
+            self._meltano_process = Popen(
+                self._command,
                 stdout=PIPE,
                 stderr=STDOUT,
                 cwd=os.getenv(
@@ -108,7 +89,7 @@ class MeltanoELT:
                 start_new_session=True,
             )
 
-        return self._elt_process
+        return self._meltano_process
 
     @property
     def logs(self) -> Generator[str, None, None]:
@@ -118,7 +99,7 @@ class MeltanoELT:
             Generator[str, None, None]: The lines the ELT command produces.
         """
         # Loop through the stdout of the ELT process
-        for line in iter(self.elt_process.stdout.readline, b""):
+        for line in iter(self.meltano_process.stdout.readline, b""):
             yield line.decode("utf-8").rstrip()
 
     def run(
@@ -128,15 +109,10 @@ class MeltanoELT:
         """Run `meltano elt` command yielding asset materialization and producing logs.
 
         Args:
-            name (str): The name of the solid.
-            tap (str): The name of the Meltano tap.
-            target (str): The name of the Meltano target.
-            job_id (str): The id of the job.
-            full_refresh (bool): Whether to ignore existing state.
-            env_vars (Optional[dict]): Additional environment variables to pass to the
-                command context.
             log (SolidExecutionContext.log): The solid execution context's logger.
         """
+        log.info(f"Running Meltano command: {self._command}")
+
         # Read the Meltano logs, and log them to the Dagster logger
         # Save tracebacks and exceptions for logging as failures
         error_flag = 0
@@ -149,9 +125,9 @@ class MeltanoELT:
                 log.info(line)
 
         # Wait for the process to finish
-        self.elt_process.wait()
+        self.meltano_process.wait()
 
-        return_code = self.elt_process.returncode
+        return_code = self.meltano_process.returncode
 
         # If the elt process failed
         if return_code:
@@ -165,3 +141,46 @@ class MeltanoELT:
                 raise Failure(description=error)
         else:
             log.info(f"Meltano exited with return code {return_code}")
+
+
+class MeltanoELT(MeltanoCore):
+    """Control `meltano elt` command."""
+
+    def __init__(
+        self,
+        tap: str,
+        target: str,
+        job_id: str,
+        full_refresh: bool,
+        tap_config: Optional[dict] = None,
+        target_config: Optional[dict] = None,
+        env_vars: Optional[dict] = None,
+    ) -> None:
+        """Initialize a new Meltano ELT process.
+
+        Args:
+            job_id (str): The id of the job.
+            full_refresh (bool): Whether to ignore existing state.
+        """
+        super().__init__(tap, target, tap_config, target_config, env_vars)
+
+        self._job_id = job_id
+        self._full_refresh = full_refresh
+        self._command = self.elt_command
+
+    @property
+    def elt_command(self) -> List[str]:
+        """Constructs all the parts of the ELT command.
+
+        Returns:
+            List[str]: All parts of the ELT command.
+        """
+        # All default parts of the command
+        elt_command = ["meltano", "elt", self._tap, self._target, "--job_id", self._job_id]
+
+        # If the user specified a full refresh
+        if self._full_refresh:
+            elt_command += ["--full-refresh"]
+
+        self._command = elt_command
+        return elt_command

--- a/dagster_meltano/meltano_select.py
+++ b/dagster_meltano/meltano_select.py
@@ -1,0 +1,66 @@
+from typing import List, Optional
+
+from dagster import Failure, SolidExecutionContext
+
+from dagster_meltano.meltano_elt import MeltanoCore
+
+
+class MeltanoSelect(MeltanoCore):
+    """Control `meltano select` command."""
+
+    def __init__(
+        self,
+        tap: str,
+        target: Optional[str] = None,
+        tap_config: Optional[dict] = None,
+        target_config: Optional[dict] = None,
+        env_vars: Optional[dict] = None,
+        patterns: Optional[List[List[str]]] = None,
+    ) -> None:
+        """Initialize a new Meltano ELT process.
+
+        Args:
+            patterns (Optional[List[List[str]]]): The entity pattern(s) to use in select
+                command. Each item in the parent list should contain a list of 2-3 elements.
+                If two elements, the first element is the entity pattern and the second is the
+                attribute pattern. If three elements the first element should be '--exclude'
+                or '--remove'.
+        """
+        super().__init__(tap, target, tap_config, target_config, env_vars)
+
+        if patterns is None:
+            patterns = []
+
+        self._patterns: list = patterns
+        self._command = None
+
+    def select_command(self, pattern: List[str]) -> List[str]:
+        """Constructs all the parts of the `select` command.
+        See https://meltano.com/docs/command-line-interface.html#select.
+
+        Args:
+            pattern (List[str]): The list of cli arguments to append to the command.
+        Returns:
+            List[str]: All parts of the ELT command.
+        """
+        # All default parts of the command
+        select_command = ["meltano", "select", self._tap]
+
+        # If the user specified to list the current selected tap attributes
+        select_command += pattern
+
+        self._command = select_command
+        return select_command
+
+    def run_select_commands(self, log: SolidExecutionContext.log) -> List[List[str]]:
+        """Iterates through all select commands provided."""
+        cmds = []
+        for pattern in self._patterns:
+            if isinstance(pattern, list):
+                cmds.append(self.select_command(pattern))
+                self._meltano_process = None  # resets the process
+                self.run(log=log)
+            else:
+                raise Failure("'patterns' parameter must be a list of lists")
+
+        return cmds

--- a/dagster_meltano/tests/meltano_elt_pipeline.py
+++ b/dagster_meltano/tests/meltano_elt_pipeline.py
@@ -3,7 +3,11 @@ import json
 
 from dagster import pipeline, solid
 
-from dagster_meltano.dagster_types import MeltanoEltArgsType, MeltanoEnvVarsType
+from dagster_meltano.dagster_types import (
+    MeltanoEltArgsType,
+    MeltanoEnvVarsType,
+    MeltanoSelectPatternsType,
+)
 from dagster_meltano.solids import MeltanoEltSolid
 
 
@@ -21,6 +25,15 @@ def env_vars() -> MeltanoEnvVarsType:
     return {"TAP_CSV__SELECT": json.dumps(["sample.id"])}
 
 
+@solid
+def select_patterns() -> MeltanoSelectPatternsType:
+    return [["sample", "*"]]
+
+
 @pipeline
 def meltano_elt_pipeline():
-    MeltanoEltSolid("csv_to_jsonl").solid(elt_args=elt_args(), env_vars=env_vars())
+    MeltanoEltSolid("csv_to_jsonl").solid(
+        elt_args=elt_args(),
+        env_vars=env_vars(),
+        select_patterns=select_patterns(),
+    )

--- a/dagster_meltano/tests/meltano_elt_pipeline.py
+++ b/dagster_meltano/tests/meltano_elt_pipeline.py
@@ -27,7 +27,7 @@ def env_vars() -> MeltanoEnvVarsType:
 
 @solid
 def select_patterns() -> MeltanoSelectPatternsType:
-    return [["sample", "*"]]
+    return [["sample", "*"], ['--list', '--all']]
 
 
 @pipeline

--- a/dagster_meltano/tests/test_dagster_types.py
+++ b/dagster_meltano/tests/test_dagster_types.py
@@ -1,0 +1,29 @@
+from dagster_meltano.dagster_types import _is_list_of_lists
+
+
+def test_is_list_of_lists_empty():
+    assert _is_list_of_lists([])
+
+
+def test_is_list_of_lists_single_empty():
+    assert _is_list_of_lists([[]])
+
+
+def test_is_list_of_lists_single():
+    assert _is_list_of_lists([["foo", "bar"]])
+
+
+def test_is_list_of_lists_multiple():
+    assert _is_list_of_lists([["foo", "bar"], ["spam", "is", "good"]])
+
+
+def test_is_list_of_lists_error_type():
+    assert not _is_list_of_lists({})
+
+
+def test_is_list_of_lists_error_single_type():
+    assert not _is_list_of_lists([{}])
+
+
+def test_is_list_of_lists_single_error():
+    assert not _is_list_of_lists([["spam", 3]])

--- a/dagster_meltano/tests/test_meltano_elt.py
+++ b/dagster_meltano/tests/test_meltano_elt.py
@@ -26,7 +26,7 @@ def _create_meltano_elt(full_refresh: bool = True) -> MeltanoELT:
 
 
 def test_meltano_elt_construction():
-    """On successfull creation no errors should be raised."""
+    """On successful creation no errors should be raised."""
     meltano_elt = _create_meltano_elt()
 
     # Test if the instance is of the right type

--- a/dagster_meltano/tests/test_meltano_select.py
+++ b/dagster_meltano/tests/test_meltano_select.py
@@ -1,0 +1,64 @@
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from dagster import build_solid_context
+
+from dagster_meltano.meltano_select import MeltanoSelect
+from dagster_meltano.tests.utils import read_output_file
+
+os.environ["MELTANO_PROJECT_ROOT"] = (Path(__file__).parents[2] / "meltano").__str__()
+
+# Default parameters supplied to MeltanoELT
+meltano_elt_params = {
+    "tap": "tap-csv",
+    "target": "target-json",
+}
+
+
+def _create_meltano_select(select_args: Optional[dict] = None) -> MeltanoSelect:
+    """This function creates an instance of the MeltanoSelect class. Is used by the testing functions.
+
+    Args:
+        select_args (dict, optional): Dictionary containing all relevant arugments to test.
+
+    Returns:
+        MeltanoSelect: The instance of the MeltanoSelect class.
+    """
+    # Inject the additional args
+    params = {**meltano_elt_params, **select_args}
+
+    # Create the instance
+    return MeltanoSelect(**params)
+
+
+def test_meltano_select_command_list_opt_current():
+    """Test if the generated meltano select command is of the correct format."""
+    meltano_select = _create_meltano_select({})
+
+    assert meltano_select.select_command(["this", "is", "a", "test"]) == [
+        "meltano",
+        "select",
+        meltano_elt_params["tap"],
+        "this",
+        "is",
+        "a",
+        "test",
+    ]
+
+
+def test_meltano_select_run_select_commands_patterns():
+    """Test if the generated meltano select command is of the correct format."""
+    meltano_select = _create_meltano_select(
+        {"patterns": [["test", "this"], ["--remove", "test", "this"]]}
+    )
+    context = build_solid_context()
+    res = meltano_select.run_select_commands(context.log)
+
+    output_filepath = Path(os.environ["MELTANO_PROJECT_ROOT"]) / "meltano.yml"
+    meltano_yml = read_output_file(output_filepath, json_lines=False)
+
+    assert res[0] == ["meltano", "select", meltano_elt_params["tap"], "test", "this"]
+    assert res[1] == ["meltano", "select", meltano_elt_params["tap"], "--remove", "test", "this"]
+    assert not re.search(r"test\.this", meltano_yml)  # make sure the second pattern actually ran

--- a/dagster_meltano/tests/test_solids.py
+++ b/dagster_meltano/tests/test_solids.py
@@ -4,9 +4,11 @@ import re
 from pathlib import Path
 
 import pytest
-from dagster import AssetMaterialization, execute_solid
+from dagster import AssetMaterialization, build_solid_context, execute_solid
 
 from dagster_meltano.solids import MeltanoEltSolid
+from dagster_meltano.tests.test_meltano_select import _create_meltano_select
+from dagster_meltano.tests.utils import len_output_file, read_output_file, reset_output_file
 
 os.environ["MELTANO_PROJECT_ROOT"] = (Path(__file__).parents[2] / "meltano").__str__()
 
@@ -73,11 +75,7 @@ def test_meltano_elt_solid_env_vars():
     """Config env vars should override input provided env vars."""
     output_filepath = Path(os.environ["MELTANO_PROJECT_ROOT"]) / "load" / "sample.jsonl"
 
-    def len_output_file(filepath):
-        with open(filepath, "r", encoding="utf-8") as f:
-            file = f.read()
-        return len(file)
-
+    reset_output_file(output_filepath)
     initial_output_file_len = len_output_file(output_filepath)
 
     result = execute_solid(
@@ -90,6 +88,7 @@ def test_meltano_elt_solid_env_vars():
     )
 
     final_output_file_len = len_output_file(output_filepath)
+    reset_output_file(output_filepath)
 
     materializations = result.materializations_during_compute
     meltano_materialization = materializations[0]
@@ -148,3 +147,36 @@ def test_meltano_error_logging_traceback():
     assert re.search("traceback", e.value.args[0], re.IGNORECASE)
     assert re.search("most recent call last", e.value.args[0], re.IGNORECASE)  # from true traceback
     assert re.search("Loader 'target-json' is not known to Meltano", e.value.args[0], re.IGNORECASE)
+
+
+def test_meltano_elt_solid_select():
+    """Should run select command"""
+    output_filepath = Path(os.environ["MELTANO_PROJECT_ROOT"]) / "load" / "sample.jsonl"
+    reset_output_file(output_filepath)
+
+    result = execute_solid(
+        MeltanoEltSolid("csv_to_jsonl").solid,
+        run_config={"solids": {"csv_to_jsonl": {"config": {"full_refresh": True}}}},
+        input_values={
+            "elt_args": {"tap": "tap-csv", "target": "target-jsonl"},
+            "select_patterns": [["sample", "id"], ["sample", "first_name"]],
+        },
+    )
+
+    output = read_output_file(output_filepath)
+    reset_output_file(output_filepath)
+
+    # clean up
+    meltano_select = _create_meltano_select(
+        {"patterns": [["--rm", "sample", "id"], ["--rm", "sample", "first_name"]]}
+    )
+    context = build_solid_context()
+    meltano_select.run_select_commands(context.log)
+
+    assert result.success
+    assert len(result.materializations_during_compute) == 1
+    assert output == [
+        {"id": "1", "first_name": "peter"},
+        {"id": "2", "first_name": "jan"},
+        {"id": "3", "first_name": "flim"},
+    ]

--- a/dagster_meltano/tests/utils.py
+++ b/dagster_meltano/tests/utils.py
@@ -1,0 +1,29 @@
+import json
+from typing import List
+
+
+def reset_output_file(filepath):
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write("")
+
+
+def len_output_file(filepath):
+    with open(filepath, "r", encoding="utf-8") as f:
+        file = f.read()
+    return len(file)
+
+
+def read_output_file(filepath, json_lines: bool = True) -> List:
+    if json_lines:
+        with open(filepath, "r", encoding="utf-8") as f:
+            file = f.readlines()
+
+        lines_json = []
+        for line in file:
+            lines_json.append(json.loads(line))
+        return lines_json
+
+    else:
+        with open(filepath, "r", encoding="utf-8") as f:
+            file = f.read()
+        return file

--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -12,7 +12,10 @@ plugins:
         path: extract/sample.csv
         keys:
         - id
-    select: []
+    select:
+    - test.this
+    - sample.*
+    - sample.*
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -8,9 +8,11 @@ plugins:
     pip_url: git+https://github.com/MeltanoLabs/tap-csv.git
     config:
       files:
-        - entity: "sample"
-          path: extract/sample.csv
-          keys: ["id"]
+      - entity: sample
+        path: extract/sample.csv
+        keys:
+        - id
+    select: []
   loaders:
   - name: target-jsonl
     variant: andyh1203


### PR DESCRIPTION
Added `meltano select` capabilities into the Meltano ELT solid. The architecture path I decided to follow included the abstraction of the cli command core from the actual `meltano elt` command construction. This was done so that other solid types could be created in the future (e.g., an independent solid for each command in Meltano's cli). The other option would be to include each command as a separate method under the same monolithic class which might be simpler for this implementation. I worried though about future extensibility more than ease of development in this case.

Select commands can be run prior to the `meltano elt` command by providing a list of select command to run omitting the `meltano select tap-whatever` portion. This seemed to be the most straight forward way of accomplishing it. 