### PR TITLE
feat(meltano): :sparkles: Inject environement variable for ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ def repository():
     return [meltano_run_job]
 ```
 
+You can inject Meltano config with the following Dagster config.
+
+```yaml
+ops:
+  tap_smoke_test_target_jsonl:
+    config:
+      env:
+        TAP_SMOKE_TEST_STREAMS: '[{"stream_name": "new-stream", "input_filename": "demo.json"}]'
+```
+
 ## Development using VSCode
 
 1. Open this repository in Visual Studio Code.

--- a/dagster_meltano/meltano_invoker.py
+++ b/dagster_meltano/meltano_invoker.py
@@ -11,7 +11,6 @@ from dagster import get_dagster_logger
 from dagster_meltano.log_processing import LogProcessor
 from dagster_meltano.log_processing.passthrough_processor import PassthroughLogProcessor
 
-# log = structlog.get_logger()
 log = get_dagster_logger()
 
 

--- a/dagster_meltano/meltano_resource.py
+++ b/dagster_meltano/meltano_resource.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from functools import lru_cache
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from dagster import resource, Field
 
@@ -19,13 +19,15 @@ class MeltanoResource(metaclass=Singleton):
         self,
         project_dir: str = None,
         meltano_bin: Optional[str] = "meltano",
+        env: Optional[Dict[str, Any]] = {},
     ):
         self.project_dir = project_dir
         self.meltano_bin = meltano_bin
         self.meltano_invoker = MeltanoInvoker(
             bin=meltano_bin,
             cwd=project_dir,
-            log_level="info",  # TODO: Get this from the resource config
+            log_level="info", # TODO: Get this from the resource config
+            env=env, 
         )
 
     async def load_json_from_cli(self, command: List[str]) -> dict:


### PR DESCRIPTION
Closes #19 
Use case : I want to be able to inject environment variable to change the meltano extraction.

This is a first proposal which works on my use case. 
- **tap-rest-api-msdk**
- **target-json**

Defintion `meltano.yaml` in 
```
plugins:
  extractors:
  - name: tap-rest-api-msdk
    variant: widen
    pip_url: tap-rest-api-msdk
    config:
      api_url: ...
      streams:
      - name: ...
        path: /...
      params:
        date_after: 01/01/2019
        date_before: 01/12/2019
```

I want to control **date_after** and **date_before** variable. 
With [tap-rest-api-msdk](https://hub.meltano.com/extractors/tap-rest-api-msdk/#params-setting) we can setup `TAP_REST_API_MSDK_PARAMS`
meltano command resumes to:
` TAP_REST_API_MSDK_PARAMS='{"date_after": "01/01/2022", "date_before":"01/12/2022"}' meltano run tap-rest-api-msdk target-jsonl`

How I solve this: 
- add **env** to the **meltano ops generator**
- add **env** to **ins** op function as an optional arguments
- update **env** parameter to **MeltanoInvoker** instance

Looks like this in UI where env is made optional: 
![image](https://user-images.githubusercontent.com/25283272/212472104-660ab6c2-e195-46af-80b7-0c675d1966c1.png)

![image](https://user-images.githubusercontent.com/25283272/212472129-266da7d1-52e9-4d2b-a9e6-0bad1942d4d0.png)

⚠️ In this exemple, meltano environment variable needs to be a string and should not be interpreted as a python object. 

Any feedback is welcome. 



