### PR TITLE
feat: remove type annotation for context param in meltano_install op

### DIFF
--- a/dagster_meltano/ops.py
+++ b/dagster_meltano/ops.py
@@ -91,8 +91,7 @@ def meltano_command_op(
         env = {**env, **config_env}
 
         # Run the Meltano command
-        output = meltano_resource.execute_command(
-            f"{command}", env, context.log)
+        output = meltano_resource.execute_command(f"{command}", env, context.log)
 
         # Return the logs
         return output
@@ -111,7 +110,9 @@ def meltano_run_op(
     same repository.
     """
     dagster_name = generate_dagster_name(command)
-    return meltano_command_op(command=f"run {command} --force", dagster_name=dagster_name)
+    return meltano_command_op(
+        command=f"run {command} --force", dagster_name=dagster_name
+    )
 
 
 @op(
@@ -129,7 +130,7 @@ def meltano_run_op(
         )
     },
 )
-def meltano_install_op(context: OpExecutionContext):
+def meltano_install_op(context):
     """
     Run `meltano install` using a Dagster op.
     """


### PR DESCRIPTION
The `OpExecutionContext` type annotation in [`meltano_install`](https://github.com/quantile-development/dagster-meltano/blob/master/dagster_meltano/ops.py#L132) is raising errors like that when running with `dagster >=1.5.0` 

![image](https://github.com/quantile-development/dagster-meltano/assets/23472449/d0e332d8-3de0-42e4-8dad-29de9221a0ad)

This is expected as 1.5.0 introduces some breaking changes in that area. See release notes:
- https://github.com/dagster-io/dagster/releases/tag/1.5.0


When type hint is remove, dagster loads fine.
