### PR TITLE
remove OpExecutionContext type annotation in dagster_op func

### DIFF
--- a/dagster_meltano/ops.py
+++ b/dagster_meltano/ops.py
@@ -5,7 +5,6 @@ from dagster import (
     In,
     Nothing,
     OpDefinition,
-    OpExecutionContext,
     Out,
     get_dagster_logger,
     op,
@@ -71,14 +70,14 @@ def meltano_command_op(
         },
     )
     def dagster_op(
-        context: OpExecutionContext,
+        context,
         env: Optional[dict],
     ) -> str:
         """
         Run `meltano run <command>` using a Dagster op.
 
         Args:
-            context (OpExecutionContext): The Dagster op execution context.
+            context: The Dagster op execution context.
         """
         meltano_resource: MeltanoResource = context.resources.meltano
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dagster-meltano"
-version = "1.5.1"
+version = "1.5.2"
 description = "A dagster plugin that allows you to run your Meltano project inside Dagster."
 authors = ["Quantile Development"]
 license = "Apache 2.0"


### PR DESCRIPTION
The error causes for the same reason with [that](https://github.com/quantile-development/dagster-meltano/pull/41) fix. I have removed type annotation in `dagster_op` function as well. #41 