### PR TITLE
draft: Strip equal sign in generate_dagster_name() and add possibillity of custom dagster_name

### DIFF
--- a/dagster_meltano/ops.py
+++ b/dagster_meltano/ops.py
@@ -24,7 +24,7 @@ STDOUT = 1
 @lru_cache
 def meltano_command_op(
     command: str,
-    dagster_name: Optional[str] = None,
+    dagster_name: str,
 ) -> OpDefinition:
     """
     Run `meltano <command>` using a Dagster op.
@@ -34,13 +34,11 @@ def meltano_command_op(
 
     Args:
         command (str): The Meltano command to run.
-        dagster_name (Optional[str], optional): The Dagster name to use for the op.
-            Defaults to None.
+        dagster_name (str): The Dagster name to use for the op.
 
     Returns:
         OpDefinition: The Dagster op definition.
     """
-    dagster_name = dagster_name or generate_dagster_name(command)
     ins = {
         "after": In(Nothing),
         "env": In(
@@ -101,14 +99,23 @@ def meltano_command_op(
 @lru_cache
 def meltano_run_op(
     command: str,
+    dagster_name: Optional[str] = None, 
+    
 ) -> OpDefinition:
     """
     Run `meltano run <command>` using a Dagster op.
 
     This factory is cached to make sure the same commands can be reused in the
     same repository.
+
+    Args:
+    command (str): The Meltano command to run.
+    dagster_name (Optional[str], optional): The Dagster name to use for the op.
+        Defaults to None.
     """
-    dagster_name = generate_dagster_name(command)
+    # if not set, generate a dagster_name from the command
+    dagster_name = dagster_name or generate_dagster_name(command)
+
     return meltano_command_op(
         command=f"run {command} --force", dagster_name=dagster_name
     )

--- a/dagster_meltano/utils.py
+++ b/dagster_meltano/utils.py
@@ -16,7 +16,7 @@ def generate_dagster_name(input_string) -> str:
     """
     Generate a dagster safe name (^[A-Za-z0-9_]+$.)
     """
-    return input_string.replace("-", "_").replace(" ", "_").replace(":", "_")
+    return input_string.replace("-", "_").replace(" ", "_").replace(":", "_").replace("=", "_")
 
 
 def generate_dbt_group_name(node_info: dict) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-dagster = ">=1.5.0,<2"
+dagster = ">=1.3,<2"
 dagster-shell = ">=0,<1"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-dagster = ">=1.3,<2"
+dagster = ">=1.5.0,<2"
 dagster-shell = ">=0,<1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_meltano_command.py
+++ b/tests/test_meltano_command.py
@@ -9,7 +9,7 @@ MELTANO_PROJECT_TEST_PATH = str(Path(__file__).parent / "meltano_test_project")
 
 @job(resource_defs={"meltano": meltano_resource})
 def meltano_command_job():
-    meltano_command_op("install extractor tap-smoke-test")()
+    meltano_command_op("install extractor tap-smoke-test", "custom_job_name")()
 
 
 def test_meltano_command():


### PR DESCRIPTION
Adding `.replace("=", "_")` the the `generate_dagster_name` function. As Meltano prod runs are called with:
```
meltano --environment=prod run your:command
```

Draft: As I was not able to test this 
