### PR TITLE
fix(resource): use meltano_bin param

### DIFF
--- a/dagster_meltano/meltano_resource.py
+++ b/dagster_meltano/meltano_resource.py
@@ -59,7 +59,7 @@ class MeltanoResource(metaclass=Singleton):
             str: The output of the command.
         """
         output, exit_code = execute_shell_command(
-            f"meltano {command}",
+            f"{self.meltano_bin} {command}",
             env={**self.default_env, **env},
             output_logging="STREAM",
             log=logger,
@@ -85,7 +85,7 @@ class MeltanoResource(metaclass=Singleton):
         """
         # Create the subprocess, redirect the standard output into a pipe
         proc = await asyncio.create_subprocess_exec(
-            "meltano",
+            self.meltano_bin,
             *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
I've been having a lot of trouble trying to get meltano running in a dagster code location as a package
i.e.

```
load_from:
  - python_package:
      package_name: dag_meltano
      executable_path: dag/meltano/.venv/bin/python
```

I kept butting up against #53, which seems like meltano isn't installed in the virtualenv, but I can confirm it definitely is in my package's virtualenv 🤔 

I wanted to specify the meltano bin manually and noticed this was already here, but did nothing? So I think this is somewhat productive and I'm hoping I can use this to specify the path directly to the bin